### PR TITLE
fix: fixed update-device fw arg

### DIFF
--- a/src/update-device.ts
+++ b/src/update-device.ts
@@ -124,7 +124,7 @@ program
     process.env.MQTT_ENDPOINT,
   )
   .option(
-    '-a, --app-fw-version <nextAppFwVersion>',
+    '-a, --next-app-fw-version <nextAppFwVersion>',
     'Next version of the app firmware',
   )
   .parse(process.argv);


### PR DESCRIPTION
update-device script was looking for incorrect `nextAppFwVersion` arg, commander was sending `appFwVersion`. 